### PR TITLE
Update DU status options

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -11,7 +11,7 @@ class DURecord(Base):
     __tablename__ = "du_record"
     id = Column(Integer, primary_key=True, index=True)
     du_id = Column(String(32), index=True, nullable=False)
-    status = Column(String(20), nullable=False)
+    status = Column(String(64), nullable=False)
     remark = Column(Text, nullable=True)
     photo_url = Column(Text, nullable=True)
     lng = Column(String(20), nullable=True) #经度


### PR DESCRIPTION
## Summary
- allow longer DU record statuses to store the new set of allowed values
- centralize the legal status list and validate requests against the updated options
- add "运输中" and "过夜" to the allowed DU status values

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cd306bcc50832091da15f47d41f387