### PR TITLE
Update DN list sync with latest records

### DIFF
--- a/app/crud.py
+++ b/app/crud.py
@@ -1,7 +1,7 @@
 # crud.py
 from __future__ import annotations
 
-from typing import Optional, Iterable, Tuple, List, Set
+from typing import Optional, Iterable, Tuple, List, Set, Dict
 from sqlalchemy.orm import Session
 from sqlalchemy import and_
 from .models import DU, DURecord, DN, DNRecord
@@ -334,3 +334,24 @@ def get_existing_dn_numbers(db: Session, dn_numbers: Iterable[str]) -> Set[str]:
 
     rows = db.query(DN.dn_number).filter(DN.dn_number.in_(unique_numbers)).all()
     return {row[0] for row in rows}
+
+
+def get_latest_dn_records_map(db: Session, dn_numbers: Iterable[str]) -> Dict[str, DNRecord]:
+    unique_numbers = [number for number in {number for number in dn_numbers if number}]
+    if not unique_numbers:
+        return {}
+
+    q = (
+        db.query(DNRecord)
+        .filter(DNRecord.dn_number.in_(unique_numbers))
+        .order_by(DNRecord.dn_number.asc(), DNRecord.created_at.desc(), DNRecord.id.desc())
+    )
+
+    latest: Dict[str, DNRecord] = {}
+    for rec in q:
+        key = rec.dn_number
+        if key not in latest:
+            latest[key] = rec
+            if len(latest) == len(unique_numbers):
+                break
+    return latest

--- a/app/main.py
+++ b/app/main.py
@@ -26,12 +26,14 @@ from .crud import (
     update_dn_record,
     delete_dn_record,
     get_existing_dn_numbers,
+    get_latest_dn_records_map,
 )
 from .storage import save_file
 from fastapi.responses import JSONResponse
 import logging, traceback
 import gspread
 import pandas as pd
+from .models import DN
 
 # ====== 启动与静态 ======
 os.makedirs(settings.storage_disk_path, exist_ok=True)
@@ -467,6 +469,7 @@ def update_dn(
         db,
         dn_number,
         du_id=du_id_normalized,
+        status=status,
         remark=remark,
         photo_url=photo_url,
         lng=lng_val,
@@ -531,7 +534,7 @@ def batch_update_dn(
             add_failure(number, "DN number 已存在")
             continue
 
-        ensure_dn(db, number)
+        ensure_dn(db, number, status="NO STATUS")
         add_dn_record(
             db,
             dn_number=number,
@@ -724,6 +727,17 @@ def edit_dn_record(
     if not rec:
         raise HTTPException(status_code=404, detail="Record not found")
 
+    ensure_dn(
+        db,
+        rec.dn_number,
+        du_id=rec.du_id,
+        status=rec.status,
+        remark=rec.remark,
+        photo_url=rec.photo_url,
+        lng=rec.lng,
+        lat=rec.lat,
+    )
+
     return {"ok": True, "id": rec.id}
 
 
@@ -888,7 +902,7 @@ async def get_dn_stats(date: str):
 
 
 @app.get("/api/dn/list")
-async def get_dn_list():
+async def get_dn_list(db: Session = Depends(get_db)):
     try:
         gc = gspread.api_key(API_KEY)
         sh = gc.open_by_url(SPREADSHEET_URL)
@@ -897,17 +911,74 @@ async def get_dn_list():
         logger.exception("Failed to fetch DN list: %s", exc)
         return {"ok": False, "errMsg": "Failed to fetch DN list"}
 
-    if combined_df.empty:
+    records: List[dict[str, Any]] = []
+    dn_numbers: set[str] = set()
+
+    if not combined_df.empty:
+        for record in combined_df.to_dict(orient="records"):
+            cleaned = {key: normalize_sheet_value(value) for key, value in record.items()}
+            raw_number = cleaned.get("dn_number")
+            raw_number_str = str(raw_number).strip() if raw_number is not None else ""
+            normalized_number = normalize_dn(raw_number_str) if raw_number_str else ""
+            if not normalized_number:
+                continue
+            cleaned["dn_number"] = normalized_number
+            if all(value is None for key, value in cleaned.items() if key != "dn_number"):
+                continue
+            records.append(cleaned)
+            dn_numbers.add(normalized_number)
+
+    latest_records_for_update = get_latest_dn_records_map(db, dn_numbers)
+
+    for entry in records:
+        number = entry["dn_number"]
+        sheet_fields = {key: entry.get(key) for key in SHEET_COLUMNS if key != "dn_number"}
+        latest = latest_records_for_update.get(number)
+        if latest:
+            if not sheet_fields.get("du_id") and latest.du_id:
+                sheet_fields["du_id"] = latest.du_id
+            sheet_fields.update({
+                "status": latest.status,
+                "remark": latest.remark,
+                "photo_url": latest.photo_url,
+                "lng": latest.lng,
+                "lat": latest.lat,
+            })
+        ensure_dn(db, number, **sheet_fields)
+
+    query = db.query(DN)
+    if dn_numbers:
+        query = query.filter(DN.dn_number.in_(dn_numbers))
+    items = query.order_by(DN.dn_number.asc()).all()
+
+    if not items:
         return {"ok": True, "data": []}
 
-    records: List[dict[str, Any]] = []
-    for record in combined_df.to_dict(orient="records"):
-        cleaned = {key: normalize_sheet_value(value) for key, value in record.items()}
-        if all(value is None for value in cleaned.values()):
-            continue
-        records.append(cleaned)
+    latest_records = get_latest_dn_records_map(db, [it.dn_number for it in items])
 
-    return {"ok": True, "data": records}
+    data: List[dict[str, Any]] = []
+    for it in items:
+        row: dict[str, Any] = {
+            "id": it.id,
+            "dn_number": it.dn_number,
+            "created_at": it.created_at.isoformat() if it.created_at else None,
+            "status": it.status,
+            "remark": it.remark,
+            "photo_url": it.photo_url,
+            "lng": it.lng,
+            "lat": it.lat,
+        }
+        for column in SHEET_COLUMNS:
+            if column == "dn_number":
+                continue
+            row[column] = getattr(it, column)
+        latest = latest_records.get(it.dn_number)
+        row["latest_record_created_at"] = (
+            latest.created_at.isoformat() if latest and latest.created_at else None
+        )
+        data.append(row)
+
+    return {"ok": True, "data": data}
 
 
 @app.get("/api/dn/{dn_number}")

--- a/app/models.py
+++ b/app/models.py
@@ -24,6 +24,7 @@ class DN(Base):
     id = Column(Integer, primary_key=True, index=True)
     dn_number = Column(String(64), unique=True, index=True, nullable=False)
     du_id = Column(String(64), nullable=True)
+    status = Column(String(64), nullable=True)
     remark = Column(Text, nullable=True)
     photo_url = Column(Text, nullable=True)
     lng = Column(String(20), nullable=True)

--- a/app/settings.py
+++ b/app/settings.py
@@ -7,7 +7,12 @@ class Settings(BaseSettings):
     database_url: str | None = os.getenv("DATABASE_URL")  # 不给默认，缺失就暴露问题
     allowed_origins: list[str] = []
     storage_driver: str = os.getenv("STORAGE_DRIVER", "disk")
-    storage_disk_path: str = os.getenv("storage_DISK_PATH", "/data/uploads")
+    # 兼容早期错误拼写的环境变量名称
+    storage_disk_path: str = (
+        os.getenv("STORAGE_DISK_PATH")
+        or os.getenv("storage_DISK_PATH")
+        or "/data/uploads"
+    )
     s3_endpoint: str = os.getenv("S3_ENDPOINT", "")
     s3_region: str = os.getenv("S3_REGION", "")
     s3_bucket: str = os.getenv("S3_BUCKET", "")


### PR DESCRIPTION
## Summary
- add a status column to DN plus a helper to fetch the latest DNRecord per number
- persist the latest DNRecord info when creating or editing DN updates
- refresh /api/dn/list to sync Google Sheet rows into the database and return all stored fields enriched with latest record data

## Testing
- python -m compileall app


------
https://chatgpt.com/codex/tasks/task_e_68ce6741b3988320994a49546167c5ef