### PR TITLE
Fix storage disk path env var casing compatibility

### DIFF
--- a/app/settings.py
+++ b/app/settings.py
@@ -7,7 +7,12 @@ class Settings(BaseSettings):
     database_url: str | None = os.getenv("DATABASE_URL")  # 不给默认，缺失就暴露问题
     allowed_origins: list[str] = []
     storage_driver: str = os.getenv("STORAGE_DRIVER", "disk")
-    storage_disk_path: str = os.getenv("storage_DISK_PATH", "/data/uploads")
+    # 兼容早期错误拼写的环境变量名称
+    storage_disk_path: str = (
+        os.getenv("STORAGE_DISK_PATH")
+        or os.getenv("storage_DISK_PATH")
+        or "/data/uploads"
+    )
     s3_endpoint: str = os.getenv("S3_ENDPOINT", "")
     s3_region: str = os.getenv("S3_REGION", "")
     s3_bucket: str = os.getenv("S3_BUCKET", "")


### PR DESCRIPTION
## Summary
- make the storage disk path setting honor the correct STORAGE_DISK_PATH environment variable
- keep backwards compatibility with the previously misspelled storage_DISK_PATH variable so both branches work together

## Testing
- python -m compileall app

------
https://chatgpt.com/codex/tasks/task_e_68ceaec469d883208070b59d164ddf10