### PR TITLE
Make /api/dn/sync synchronous and expose tracebacks

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -965,12 +965,19 @@ async def _scheduled_dn_sheet_sync() -> None:
 
 
 @app.post("/api/dn/sync")
-async def trigger_dn_sync():
+def trigger_dn_sync():
     try:
-        synced_numbers = await run_dn_sheet_sync_once()
+        synced_numbers = _sync_dn_sheet_with_new_session()
     except Exception:
         logger.exception("Manual DN sheet sync failed")
-        raise HTTPException(status_code=500, detail="dn_sync_failed") from None
+        return JSONResponse(
+            status_code=500,
+            content={
+                "ok": False,
+                "error": "dn_sync_failed",
+                "errorInfo": traceback.format_exc(),
+            },
+        )
 
     return {
         "ok": True,


### PR DESCRIPTION
## Summary
- make the manual DN sync endpoint synchronous so it executes in the request thread
- return detailed traceback information when DN sync fails while keeping the success response intact

## Testing
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68cff546350c83209d3d74e171a6a82b