### PR TITLE
Add API to extend DN table columns dynamically

### DIFF
--- a/app/dn_columns.py
+++ b/app/dn_columns.py
@@ -1,0 +1,186 @@
+from __future__ import annotations
+
+import logging
+import re
+from typing import Iterable, List, Mapping
+
+from sqlalchemy import Column, Text as SAText, inspect as sa_inspect, text
+from sqlalchemy.engine import Engine
+from sqlalchemy.orm import Session
+
+from .db import engine
+from .models import DN
+
+logger = logging.getLogger(__name__)
+
+# Base columns defined on the SQLAlchemy model when the application starts.
+_BASE_DN_COLUMNS = tuple(column.name for column in DN.__table__.columns)
+_BASE_DN_COLUMN_SET = set(_BASE_DN_COLUMNS)
+# Columns that should never be updated through sheet synchronization.
+_IMMUTABLE_COLUMNS = {"id", "dn_number", "created_at"}
+
+# Base sheet columns that mirror the Google Sheet structure.
+SHEET_BASE_COLUMNS: List[str] = [
+    "dn_number",
+    "du_id",
+    "status_wh",
+    "lsp",
+    "area",
+    "mos_given_time",
+    "expected_arrival_time_from_project",
+    "project_request",
+    "distance_poll_mover_to_site",
+    "driver_contact_name",
+    "driver_contact_number",
+    "delivery_type_a_to_b",
+    "transportation_time",
+    "estimate_depart_from_start_point_etd",
+    "estimate_arrive_sites_time_eta",
+    "lsp_tracker",
+    "hw_tracker",
+    "actual_depart_from_start_point_atd",
+    "actual_arrive_time_ata",
+    "subcon",
+    "subcon_receiver_contact_number",
+    "status_delivery",
+    "issue_remark",
+    "mos_attempt_1st_time",
+    "mos_attempt_2nd_time",
+    "mos_attempt_3rd_time",
+    "mos_attempt_4th_time",
+    "mos_attempt_5th_time",
+    "mos_attempt_6th_time",
+    "mos_type",
+    "region",
+    "plan_mos_date",
+]
+
+# Cache of dynamically added DN columns (in table order).
+_dynamic_columns: List[str] = []
+
+_COLUMN_NAME_PATTERN = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
+
+
+def _get_engine(bind: Engine | Session | None = None) -> Engine:
+    if isinstance(bind, Session):
+        if bind.bind is None:
+            raise RuntimeError("Session is not bound to an engine")
+        return bind.bind
+    if isinstance(bind, Engine):
+        return bind
+    return engine
+
+
+def _register_column_on_model(column_name: str) -> None:
+    """Attach a dynamic column to the SQLAlchemy model for ORM access."""
+
+    table = DN.__table__
+    if column_name in table.c:
+        return
+
+    logger.debug("Registering dynamic DN column on model: %s", column_name)
+    column = Column(column_name, SAText, nullable=True)
+    table.append_column(column)
+
+    mapper = sa_inspect(DN)
+    mapper.add_property(column_name, table.c[column_name])
+
+
+def refresh_dynamic_columns(bind: Engine | Session | None = None) -> List[str]:
+    """Reload the list of dynamic columns from the database."""
+
+    engine_obj = _get_engine(bind)
+    inspector = sa_inspect(engine_obj)
+    columns_info = inspector.get_columns("dn")
+
+    dynamic: List[str] = []
+    for info in columns_info:
+        name = info.get("name")
+        if not name or name in _BASE_DN_COLUMN_SET:
+            continue
+        dynamic.append(name)
+        _register_column_on_model(name)
+
+    global _dynamic_columns
+    _dynamic_columns = dynamic
+    return list(_dynamic_columns)
+
+
+def ensure_dynamic_columns_loaded(bind: Engine | Session | None = None) -> None:
+    if not _dynamic_columns:
+        refresh_dynamic_columns(bind)
+
+
+def get_dynamic_columns() -> List[str]:
+    return list(_dynamic_columns)
+
+
+def get_sheet_columns() -> List[str]:
+    return SHEET_BASE_COLUMNS + list(_dynamic_columns)
+
+
+def get_mutable_dn_columns() -> List[str]:
+    ensure_dynamic_columns_loaded()
+    allowed = [
+        column
+        for column in list(_BASE_DN_COLUMN_SET | set(_dynamic_columns))
+        if column not in _IMMUTABLE_COLUMNS
+    ]
+    return allowed
+
+
+def filter_assignable_dn_fields(fields: Mapping[str, object]) -> dict[str, object]:
+    """Return a dict that only includes DN columns that can be updated."""
+
+    ensure_dynamic_columns_loaded()
+    allowed = set(get_mutable_dn_columns())
+    result: dict[str, object] = {}
+    for key, value in fields.items():
+        if key in allowed:
+            result[key] = value
+    return result
+
+
+def extend_dn_columns(db: Session, column_names: Iterable[str]) -> List[str]:
+    """Ensure the DN table contains the provided columns."""
+
+    ensure_dynamic_columns_loaded(db)
+    engine_obj = _get_engine(db)
+    inspector = sa_inspect(engine_obj)
+    existing_columns = {info["name"] for info in inspector.get_columns("dn")}
+
+    added: List[str] = []
+
+    for raw_name in column_names:
+        name = raw_name.strip()
+        if not name:
+            continue
+        if name in existing_columns:
+            continue
+        if name in _BASE_DN_COLUMN_SET:
+            continue
+        if not _COLUMN_NAME_PATTERN.fullmatch(name):
+            raise ValueError(f"Invalid column name: {name}")
+
+        logger.info("Adding DN column '%s' to database", name)
+        db.execute(text(f'ALTER TABLE "dn" ADD COLUMN "{name}" TEXT'))
+        added.append(name)
+        existing_columns.add(name)
+
+    if added:
+        db.commit()
+        # Update ORM mapping and cache
+        refresh_dynamic_columns(engine_obj)
+    return added
+
+
+__all__ = [
+    "SHEET_BASE_COLUMNS",
+    "ensure_dynamic_columns_loaded",
+    "extend_dn_columns",
+    "filter_assignable_dn_fields",
+    "get_sheet_columns",
+    "get_dynamic_columns",
+    "get_mutable_dn_columns",
+    "refresh_dynamic_columns",
+]

--- a/app/main.py
+++ b/app/main.py
@@ -9,8 +9,14 @@ import asyncio
 import re, os, unicodedata
 from pathlib import Path
 
+from pydantic import BaseModel, Field
 from .settings import settings
 from .db import Base, engine, get_db, SessionLocal
+from .dn_columns import (
+    extend_dn_columns as extend_dn_table_columns,
+    get_sheet_columns,
+    refresh_dynamic_columns,
+)
 from .crud import (
     ensure_du,
     add_record,
@@ -90,6 +96,7 @@ if settings.storage_driver != "s3":
     app.mount("/uploads", StaticFiles(directory=settings.storage_disk_path, check_dir=False), name="uploads")
 
 Base.metadata.create_all(bind=engine)
+refresh_dynamic_columns(engine)
 
 # ====== 校验与清洗 ======
 DU_RE = re.compile(r"^.+$")
@@ -114,6 +121,14 @@ VALID_STATUSES: tuple[str, ...] = (
 )
 
 VALID_STATUS_DESCRIPTION = ", ".join(VALID_STATUSES)
+
+
+class DNColumnExtensionRequest(BaseModel):
+    columns: List[str] = Field(
+        ...,
+        description="DN table columns to ensure exist",
+        min_length=1,
+    )
 
 def normalize_du(s: str) -> str:
     """NFC 规整、去零宽、全角转半角、去空白、统一大写"""
@@ -463,6 +478,24 @@ def get_du_records(du_id: str, db: Session = Depends(get_db)):
 
 
 # ====== DN 接口 ======
+
+
+@app.post("/api/dn/columns/extend")
+def extend_dn_columns_api(
+    request: DNColumnExtensionRequest, db: Session = Depends(get_db)
+):
+    try:
+        added = extend_dn_table_columns(db, request.columns)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc))
+
+    return {
+        "ok": True,
+        "added_columns": added,
+        "columns": get_sheet_columns(),
+    }
+
+
 @app.post("/api/dn/update")
 def update_dn(
     dnNumber: str = Form(...),
@@ -782,41 +815,6 @@ def remove_dn_record(id: int, db: Session = Depends(get_db)):
 API_KEY = "AIzaSyCxIBYFpNlPvQUXY83S559PEVXoagh8f88"
 SPREADSHEET_URL = "https://docs.google.com/spreadsheets/d/13-D-KkkbilYmlcHHa__CZkE2xtynL--ZxekZG4lWRic/edit?gid=1258103322#gid=1258103322"
 
-SHEET_COLUMNS: List[str] = [
-    "dn_number",
-    "du_id",
-    "status_wh",
-    "lsp",
-    "area",
-    "mos_given_time",
-    "expected_arrival_time_from_project",
-    "project_request",
-    "distance_poll_mover_to_site",
-    "driver_contact_name",
-    "driver_contact_number",
-    "delivery_type_a_to_b",
-    "transportation_time",
-    "estimate_depart_from_start_point_etd",
-    "estimate_arrive_sites_time_eta",
-    "lsp_tracker",
-    "hw_tracker",
-    "actual_depart_from_start_point_atd",
-    "actual_arrive_time_ata",
-    "subcon",
-    "subcon_receiver_contact_number",
-    "status_delivery",
-    "issue_remark",
-    "mos_attempt_1st_time",
-    "mos_attempt_2nd_time",
-    "mos_attempt_3rd_time",
-    "mos_attempt_4th_time",
-    "mos_attempt_5th_time",
-    "mos_attempt_6th_time",
-    "mos_type",
-    "region",
-    "plan_mos_date",
-]
-
 MONTH_MAP = {
     "Sept": "Sep",  # 'Sept' -> 'Sep'
 }
@@ -854,7 +852,7 @@ def parse_date(date_str: str):
 
     return date_str
 
-def process_sheet_data(sheet) -> pd.DataFrame:
+def process_sheet_data(sheet, columns: List[str]) -> pd.DataFrame:
     """处理工作表数据"""
     all_values = sheet.get_all_values()
     dn_sync_logger.debug(
@@ -862,14 +860,14 @@ def process_sheet_data(sheet) -> pd.DataFrame:
     )
     data = all_values[3:]  # 从第4行开始
     trimmed: List[List[str]] = []
-    column_count = len(SHEET_COLUMNS)
+    column_count = len(columns)
     for row in data:
         row_values = row[:column_count]
         if len(row_values) < column_count:
             row_values = row_values + [""] * (column_count - len(row_values))
         trimmed.append(row_values)
 
-    df = pd.DataFrame(trimmed, columns=SHEET_COLUMNS)
+    df = pd.DataFrame(trimmed, columns=columns)
     dn_sync_logger.debug(
         "Sheet '%s' produced DataFrame with %d rows", sheet.title, len(df)
     )
@@ -878,10 +876,11 @@ def process_sheet_data(sheet) -> pd.DataFrame:
 def process_all_sheets(sh) -> pd.DataFrame:
     """处理所有符合条件的工作表并合并数据"""
     plan_sheets = fetch_plan_sheets(sh)
-    all_data = [process_sheet_data(sheet) for sheet in plan_sheets]
+    columns = get_sheet_columns()
+    all_data = [process_sheet_data(sheet, columns) for sheet in plan_sheets]
     if not all_data:
         dn_sync_logger.debug("No plan sheets found to process")
-        return pd.DataFrame(columns=SHEET_COLUMNS)
+        return pd.DataFrame(columns=columns)
     combined = pd.concat(all_data, ignore_index=True)
     dn_sync_logger.debug(
         "Combined DataFrame has %d rows and %d columns",
@@ -922,6 +921,7 @@ def sync_dn_sheet_to_db(db: Session, *, logger_obj: logging.Logger | None = None
         dn_sync_logger.exception("Failed to fetch DN sheet data")
         raise
 
+    sheet_columns: List[str] = list(combined_df.columns)
     records: List[dict[str, Any]] = []
     dn_numbers: set[str] = set()
 
@@ -963,7 +963,9 @@ def sync_dn_sheet_to_db(db: Session, *, logger_obj: logging.Logger | None = None
 
     for entry in records:
         number = entry["dn_number"]
-        sheet_fields = {key: entry.get(key) for key in SHEET_COLUMNS if key != "dn_number"}
+        sheet_fields = {
+            key: entry.get(key) for key in sheet_columns if key != "dn_number"
+        }
         latest = latest_records_for_update.get(number)
         if latest:
             if not sheet_fields.get("du_id") and latest.du_id:
@@ -1209,6 +1211,7 @@ async def get_dn_list(db: Session = Depends(get_db)):
         return {"ok": True, "data": []}
 
     latest_records = get_latest_dn_records_map(db, [it.dn_number for it in items])
+    sheet_columns = get_sheet_columns()
 
     data: List[dict[str, Any]] = []
     for it in items:
@@ -1222,7 +1225,7 @@ async def get_dn_list(db: Session = Depends(get_db)):
             "lng": it.lng,
             "lat": it.lat,
         }
-        for column in SHEET_COLUMNS:
+        for column in sheet_columns:
             if column == "dn_number":
                 continue
             row[column] = getattr(it, column)
@@ -1274,6 +1277,7 @@ def search_dn_list_api(
         }
 
     latest_records = get_latest_dn_records_map(db, [it.dn_number for it in items])
+    sheet_columns = get_sheet_columns()
 
     data: list[dict[str, Any]] = []
     for it in items:
@@ -1287,7 +1291,7 @@ def search_dn_list_api(
             "lng": it.lng,
             "lat": it.lat,
         }
-        for column in SHEET_COLUMNS:
+        for column in sheet_columns:
             if column == "dn_number":
                 continue
             row[column] = getattr(it, column)


### PR DESCRIPTION
## Summary
- add a dn_columns helper module that tracks base DN columns, refreshes dynamic columns from the database, and extends the schema safely
- expose POST /api/dn/columns/extend so administrators can add new DN columns without losing existing data
- update DN sync, list APIs, and ORM helpers to use the dynamic column set and ignore unsupported fields when persisting

## Testing
- pytest
- python -m compileall app

------
https://chatgpt.com/codex/tasks/task_e_68d00c51b1248320b87f30471f42e89e