### PR TITLE
Ensure DN columns match configured sheet columns on startup

### DIFF
--- a/app/dn_columns.py
+++ b/app/dn_columns.py
@@ -1,0 +1,210 @@
+from __future__ import annotations
+
+import logging
+import re
+from typing import Iterable, List, Mapping
+
+from sqlalchemy import Column, Text as SAText, inspect as sa_inspect, text
+from sqlalchemy.engine import Engine
+from sqlalchemy.orm import Session
+
+from .db import engine
+from .models import DN
+from .settings import settings
+
+logger = logging.getLogger(__name__)
+
+# Base columns defined on the SQLAlchemy model when the application starts.
+_BASE_DN_COLUMNS = tuple(column.name for column in DN.__table__.columns)
+_BASE_DN_COLUMN_SET = set(_BASE_DN_COLUMNS)
+# Columns that should never be updated through sheet synchronization.
+_IMMUTABLE_COLUMNS = {"id", "dn_number", "created_at"}
+
+# Default sheet columns that mirror the Google Sheet structure.
+_DEFAULT_SHEET_COLUMNS: List[str] = [
+    "dn_number",
+    "du_id",
+    "status_wh",
+    "lsp",
+    "area",
+    "mos_given_time",
+    "expected_arrival_time_from_project",
+    "project_request",
+    "distance_poll_mover_to_site",
+    "driver_contact_name",
+    "driver_contact_number",
+    "delivery_type_a_to_b",
+    "transportation_time",
+    "estimate_depart_from_start_point_etd",
+    "estimate_arrive_sites_time_eta",
+    "lsp_tracker",
+    "hw_tracker",
+    "actual_depart_from_start_point_atd",
+    "actual_arrive_time_ata",
+    "subcon",
+    "subcon_receiver_contact_number",
+    "status_delivery",
+    "issue_remark",
+    "mos_attempt_1st_time",
+    "mos_attempt_2nd_time",
+    "mos_attempt_3rd_time",
+    "mos_attempt_4th_time",
+    "mos_attempt_5th_time",
+    "mos_attempt_6th_time",
+    "mos_type",
+    "region",
+    "plan_mos_date",
+]
+
+
+def _resolve_sheet_base_columns() -> List[str]:
+    configured = [column.strip() for column in settings.dn_sheet_columns if column.strip()]
+    if configured:
+        seen: set[str] = set()
+        ordered: List[str] = []
+        for column in configured:
+            lower = column.lower()
+            if lower in seen:
+                continue
+            seen.add(lower)
+            ordered.append(column)
+        return ordered
+    return list(_DEFAULT_SHEET_COLUMNS)
+
+
+SHEET_BASE_COLUMNS: List[str] = _resolve_sheet_base_columns()
+
+# Cache of dynamically added DN columns (in table order).
+_dynamic_columns: List[str] = []
+
+_COLUMN_NAME_PATTERN = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
+
+
+def _get_engine(bind: Engine | Session | None = None) -> Engine:
+    if isinstance(bind, Session):
+        if bind.bind is None:
+            raise RuntimeError("Session is not bound to an engine")
+        return bind.bind
+    if isinstance(bind, Engine):
+        return bind
+    return engine
+
+
+def _register_column_on_model(column_name: str) -> None:
+    """Attach a dynamic column to the SQLAlchemy model for ORM access."""
+
+    table = DN.__table__
+    if column_name in table.c:
+        return
+
+    logger.debug("Registering dynamic DN column on model: %s", column_name)
+    column = Column(column_name, SAText, nullable=True)
+    table.append_column(column)
+
+    mapper = sa_inspect(DN)
+    mapper.add_property(column_name, table.c[column_name])
+
+
+def refresh_dynamic_columns(bind: Engine | Session | None = None) -> List[str]:
+    """Reload the list of dynamic columns from the database."""
+
+    engine_obj = _get_engine(bind)
+    inspector = sa_inspect(engine_obj)
+    columns_info = inspector.get_columns("dn")
+
+    dynamic: List[str] = []
+    for info in columns_info:
+        name = info.get("name")
+        if not name or name in _BASE_DN_COLUMN_SET:
+            continue
+        dynamic.append(name)
+        _register_column_on_model(name)
+
+    global _dynamic_columns
+    _dynamic_columns = dynamic
+    return list(_dynamic_columns)
+
+
+def ensure_dynamic_columns_loaded(bind: Engine | Session | None = None) -> None:
+    if not _dynamic_columns:
+        refresh_dynamic_columns(bind)
+
+
+def get_dynamic_columns() -> List[str]:
+    return list(_dynamic_columns)
+
+
+def get_sheet_columns() -> List[str]:
+    ensure_dynamic_columns_loaded()
+    base_columns = list(SHEET_BASE_COLUMNS)
+    dynamic_unique = [
+        column for column in _dynamic_columns if column not in base_columns
+    ]
+    return base_columns + dynamic_unique
+
+
+def get_mutable_dn_columns() -> List[str]:
+    ensure_dynamic_columns_loaded()
+    allowed = [
+        column
+        for column in list(_BASE_DN_COLUMN_SET | set(_dynamic_columns))
+        if column not in _IMMUTABLE_COLUMNS
+    ]
+    return allowed
+
+
+def filter_assignable_dn_fields(fields: Mapping[str, object]) -> dict[str, object]:
+    """Return a dict that only includes DN columns that can be updated."""
+
+    ensure_dynamic_columns_loaded()
+    allowed = set(get_mutable_dn_columns())
+    result: dict[str, object] = {}
+    for key, value in fields.items():
+        if key in allowed:
+            result[key] = value
+    return result
+
+
+def extend_dn_columns(db: Session, column_names: Iterable[str]) -> List[str]:
+    """Ensure the DN table contains the provided columns."""
+
+    ensure_dynamic_columns_loaded(db)
+    engine_obj = _get_engine(db)
+    inspector = sa_inspect(engine_obj)
+    existing_columns = {info["name"] for info in inspector.get_columns("dn")}
+
+    added: List[str] = []
+
+    for raw_name in column_names:
+        name = raw_name.strip()
+        if not name:
+            continue
+        if name in existing_columns:
+            continue
+        if name in _BASE_DN_COLUMN_SET:
+            continue
+        if not _COLUMN_NAME_PATTERN.fullmatch(name):
+            raise ValueError(f"Invalid column name: {name}")
+
+        logger.info("Adding DN column '%s' to database", name)
+        db.execute(text(f'ALTER TABLE "dn" ADD COLUMN "{name}" TEXT'))
+        added.append(name)
+        existing_columns.add(name)
+
+    if added:
+        db.commit()
+        # Update ORM mapping and cache
+        refresh_dynamic_columns(engine_obj)
+    return added
+
+
+__all__ = [
+    "SHEET_BASE_COLUMNS",
+    "ensure_dynamic_columns_loaded",
+    "extend_dn_columns",
+    "filter_assignable_dn_fields",
+    "get_sheet_columns",
+    "get_dynamic_columns",
+    "get_mutable_dn_columns",
+    "refresh_dynamic_columns",
+]

--- a/app/settings.py
+++ b/app/settings.py
@@ -1,6 +1,12 @@
 # app/settings.py
-from pydantic_settings import BaseSettings
+from __future__ import annotations
+
+import json
 import os
+from typing import Iterable, List
+
+from pydantic import Field
+from pydantic_settings import BaseSettings
 
 class Settings(BaseSettings):
     app_env: str = os.getenv("APP_ENV", "development")
@@ -14,11 +20,52 @@ class Settings(BaseSettings):
     s3_access_key: str = os.getenv("S3_ACCESS_KEY", "")
     s3_secret_key: str = os.getenv("S3_SECRET_KEY", "")
     storage_base_url: str = os.getenv("STORAGE_BASE_URL", "")
+    dn_sheet_columns: List[str] = Field(default_factory=list)
 
 settings = Settings()
 
 raw = os.getenv("ALLOWED_ORIGINS", "")
 settings.allowed_origins = [x.strip() for x in raw.split(",") if x.strip()] or ["*"]
+
+
+def _parse_dn_sheet_columns(raw_value: str) -> List[str]:
+    """Parse DN sheet columns from environment configuration."""
+
+    if not raw_value:
+        return []
+
+    raw_value = raw_value.strip()
+    if not raw_value:
+        return []
+
+    parsed: Iterable[str]
+    try:
+        loaded = json.loads(raw_value)
+    except json.JSONDecodeError:
+        parsed = raw_value.split(",")
+    else:
+        if isinstance(loaded, str):
+            parsed = [loaded]
+        elif isinstance(loaded, Iterable):
+            parsed = [str(item) for item in loaded]
+        else:
+            parsed = []
+
+    result: List[str] = []
+    seen: set[str] = set()
+    for item in parsed:
+        column = str(item).strip()
+        if not column:
+            continue
+        lower = column.lower()
+        if lower in seen:
+            continue
+        seen.add(lower)
+        result.append(column)
+    return result
+
+
+settings.dn_sheet_columns = _parse_dn_sheet_columns(os.getenv("DN_SHEET_COLUMNS", ""))
 
 # 校正 DATABASE_URL（必须存在）
 if not settings.database_url:


### PR DESCRIPTION
## Summary
- allow DN sheet columns to be configured via the DN_SHEET_COLUMNS environment variable
- compute sheet base columns from configuration and avoid duplicate dynamic columns
- at application startup automatically extend the DN table to include all configured sheet columns

## Testing
- pytest
- python -m compileall app

------
https://chatgpt.com/codex/tasks/task_e_68d00c51b1248320b87f30471f42e89e