### PR TITLE
Add endpoint to delete DN entries

### DIFF
--- a/app/crud.py
+++ b/app/crud.py
@@ -184,6 +184,19 @@ def ensure_dn(db: Session, dn_number: str, **fields: str | None) -> DN:
     return dn
 
 
+def delete_dn(db: Session, dn_number: str) -> bool:
+    dn = db.query(DN).filter(DN.dn_number == dn_number).one_or_none()
+    if not dn:
+        return False
+
+    db.query(DNRecord).filter(DNRecord.dn_number == dn_number).delete(
+        synchronize_session=False
+    )
+    db.delete(dn)
+    db.commit()
+    return True
+
+
 def add_dn_record(
     db: Session,
     dn_number: str,

--- a/app/main.py
+++ b/app/main.py
@@ -36,6 +36,7 @@ from .crud import (
     list_dn_records_by_dn_numbers,
     list_dn_by_dn_numbers,
     update_dn_record,
+    delete_dn,
     delete_dn_record,
     get_existing_dn_numbers,
     get_latest_dn_records_map,
@@ -1516,6 +1517,19 @@ def batch_search_dn_list(
         "page_size": page_size,
         "items": data,
     }
+
+
+@app.delete("/api/dn/{dn_number}")
+def remove_dn(dn_number: str, db: Session = Depends(get_db)):
+    normalized_number = normalize_dn(dn_number)
+    if not DN_RE.fullmatch(normalized_number):
+        raise HTTPException(status_code=400, detail="Invalid DN number")
+
+    ok = delete_dn(db, normalized_number)
+    if not ok:
+        raise HTTPException(status_code=404, detail="DN not found")
+
+    return {"ok": True}
 
 
 @app.get("/api/dn/{dn_number}")


### PR DESCRIPTION
## Summary
- add CRUD helper that deletes DN rows and related history records
- expose DELETE /api/dn/{dn_number} endpoint that validates identifiers and returns 404 when missing

## Testing
- python -m compileall app

------
https://chatgpt.com/codex/tasks/task_e_68d1770655a0832088ef89c7dc1af2c2