### PR TITLE
Fix SQLAlchemy case usage for DN ordering

### DIFF
--- a/app/crud.py
+++ b/app/crud.py
@@ -412,8 +412,8 @@ def list_dn_by_dn_numbers(
     total = base_q.count()
 
     ordering = case(
+        *[(number, index) for index, number in enumerate(numbers)],
         value=DN.dn_number,
-        whens={number: index for index, number in enumerate(numbers)},
         else_=len(numbers),
     )
 


### PR DESCRIPTION
## Summary
- update DN listing ordering clause to use SQLAlchemy 2.0 compatible case arguments

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d25723893c8320984656e626f07cfc