### PR TITLE
Add console logging handler for dn sync logger

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -77,6 +77,13 @@ if not any(
     )
     file_handler.setLevel(logging.DEBUG)
     dn_sync_logger.addHandler(file_handler)
+if not any(isinstance(handler, logging.StreamHandler) for handler in dn_sync_logger.handlers):
+    stream_handler = logging.StreamHandler()
+    stream_handler.setFormatter(
+        logging.Formatter("%(asctime)s [%(levelname)s] %(message)s")
+    )
+    stream_handler.setLevel(logging.DEBUG)
+    dn_sync_logger.addHandler(stream_handler)
 dn_sync_logger.setLevel(logging.DEBUG)
 dn_sync_logger.propagate = False
 


### PR DESCRIPTION
## Summary
- add a console stream handler to the dn sync logger so info-level messages appear in the terminal while retaining file logging

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d2797e63608320aeba39f4f171d732