### PR TITLE
Make status delivery filter case insensitive

### DIFF
--- a/app/crud.py
+++ b/app/crud.py
@@ -484,7 +484,12 @@ def search_dn_list(
     if du_id:
         conds.append(DN.du_id == du_id)
     if status_delivery:
-        conds.append(DN.status_delivery == status_delivery)
+        trimmed_status_delivery = status_delivery.strip()
+        if trimmed_status_delivery:
+            conds.append(
+                func.lower(func.trim(DN.status_delivery))
+                == trimmed_status_delivery.lower()
+            )
     if status_not_empty is True:
         conds.append(
             and_(


### PR DESCRIPTION
## Summary
- normalize status_delivery filtering by trimming and comparing in lower-case so the search endpoint ignores casing

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d27b9a38f88320ae17a3f71f5ec09f