### PR TITLE
Fix status query to filter DN.status

### DIFF
--- a/app/crud.py
+++ b/app/crud.py
@@ -462,6 +462,7 @@ def search_dn_list(
     plan_mos_dates: Sequence[str] | None = None,
     dn_number: str | None = None,
     du_id: str | None = None,
+    status_values: Sequence[str] | None = None,
     status_delivery_values: Sequence[str] | None = None,
     status_not_empty: bool | None = None,
     has_coordinate: bool | None = None,
@@ -488,6 +489,13 @@ def search_dn_list(
         conds.append(DN.dn_number == dn_number)
     if du_id:
         conds.append(DN.du_id == du_id)
+    normalized_status_values = [
+        value.strip().lower()
+        for value in (status_values or [])
+        if isinstance(value, str) and value.strip()
+    ]
+    if normalized_status_values:
+        conds.append(func.lower(func.trim(DN.status)).in_(normalized_status_values))
     normalized_status_delivery = [
         value.strip().lower()
         for value in (status_delivery_values or [])

--- a/app/main.py
+++ b/app/main.py
@@ -1511,9 +1511,14 @@ def search_dn_list_api(
     status_delivery: Optional[List[str]] = Query(None, description="Status delivery"),
     status_delivery_legacy: Optional[List[str]] = Query(
         None,
-        alias="status",
+        alias="statusDelivery",
         description="Status delivery (legacy alias)",
         include_in_schema=False,
+    ),
+    status_values_param: Optional[List[str]] = Query(
+        None,
+        alias="status",
+        description="Status",
     ),
     status_not_empty: bool | None = Query(
         None,
@@ -1546,6 +1551,7 @@ def search_dn_list_api(
     status_delivery_values = _collect_query_values(
         status_delivery, status_delivery_legacy
     )
+    status_values = _collect_query_values(status_values_param)
     lsp_values = _collect_query_values(lsp)
     region_values = _collect_query_values(region)
     status_wh_values = _collect_query_values(status_wh)
@@ -1559,6 +1565,7 @@ def search_dn_list_api(
         dn_number=dn_number,
         du_id=du_id,
         status_delivery_values=status_delivery_values,
+        status_values=status_values,
         status_not_empty=status_not_empty,
         has_coordinate=has_coordinate,
         lsp_values=lsp_values,


### PR DESCRIPTION
## Summary
- allow the `/api/dn/list/search` endpoint to accept a `status` query parameter that filters the DN.status column
- extend the DN search to apply the new status filter while keeping delivery-status filtering available via dedicated parameters

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d3abf46e5883208a1bb6b8e3310a32