### PR TITLE
Restore legacy DN column extension alias

### DIFF
--- a/app/dn_columns.py
+++ b/app/dn_columns.py
@@ -186,10 +186,17 @@ def extend_dn_columns(db: Session, column_names: Iterable[str]) -> List[str]:
     return added
 
 
+def extend_dn_table_columns(db: Session, column_names: Iterable[str]) -> List[str]:
+    """向后兼容的别名，委托给 :func:`extend_dn_columns`。"""
+
+    return extend_dn_columns(db, column_names)
+
+
 __all__ = [
     "SHEET_BASE_COLUMNS",
     "ensure_dynamic_columns_loaded",
     "extend_dn_columns",
+    "extend_dn_table_columns",
     "filter_assignable_dn_fields",
     "get_sheet_columns",
     "get_dynamic_columns",


### PR DESCRIPTION
## Summary
- add extend_dn_table_columns compatibility wrapper in dn_columns module
- export the new alias to satisfy routers and legacy imports

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d4e660241883209cab34218d96459a