### PR TITLE
Resolve DN sync logger conflict with main

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -100,19 +100,44 @@ def create_gspread_client() -> gspread.Client:
 DN_SYNC_LOG_PATH = Path(os.getenv("DN_SYNC_LOG_PATH", "/tmp/dn_sync.log")).expanduser()
 DN_SYNC_LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
 
-dn_sync_logger = logger.getChild("dn_sync")
 
-if not any(
-    isinstance(handler, logging.FileHandler)
-    and getattr(handler, "baseFilename", None) == str(DN_SYNC_LOG_PATH)
-    for handler in dn_sync_logger.handlers
-):
-    file_handler = logging.FileHandler(DN_SYNC_LOG_PATH, encoding="utf-8")
-    file_handler.setFormatter(
-        logging.Formatter("%(asctime)s [%(levelname)s] %(message)s")
-    )
-    file_handler.setLevel(logging.DEBUG)
-    dn_sync_logger.addHandler(file_handler)
+class _DnSyncLogFilter(logging.Filter):
+    """Filter ensuring only DN sync records reach the file handler."""
+
+    def filter(self, record: logging.LogRecord) -> bool:  # type: ignore[override]
+        return bool(getattr(record, "dn_sync", False))
+
+
+_dn_sync_logger = logger.getChild("dn_sync")
+_dn_sync_logger.propagate = True
+_dn_sync_file_handler: logging.FileHandler | None = None
+
+
+def _configure_dn_sync_logger(base_logger: logging.Logger) -> logging.LoggerAdapter:
+    """Configure a DN sync logger that still propagates to the shared logger."""
+
+    global _dn_sync_file_handler
+
+    current_path = getattr(_dn_sync_file_handler, "baseFilename", None)
+    desired_path = str(DN_SYNC_LOG_PATH)
+
+    if current_path != desired_path:
+        if _dn_sync_file_handler is not None:
+            base_logger.removeHandler(_dn_sync_file_handler)
+
+        handler = logging.FileHandler(DN_SYNC_LOG_PATH, encoding="utf-8")
+        handler.setFormatter(
+            logging.Formatter("%(asctime)s [%(levelname)s] %(message)s")
+        )
+        handler.setLevel(logging.DEBUG)
+        handler.addFilter(_DnSyncLogFilter())
+        base_logger.addHandler(handler)
+        _dn_sync_file_handler = handler
+
+    return logging.LoggerAdapter(base_logger, {"dn_sync": True})
+
+
+dn_sync_logger = _configure_dn_sync_logger(_dn_sync_logger)
 
 SHEET_SYNC_INTERVAL_SECONDS = 300
 _scheduler: AsyncIOScheduler | None = None
@@ -1478,8 +1503,8 @@ def get_latest_dn_sync_log_entry(db: Session = Depends(get_db)):
 
 @app.get("/api/dn/sync/log/file")
 def download_dn_sync_log():
-    for handler in dn_sync_logger.handlers:
-        flush = getattr(handler, "flush", None)
+    if _dn_sync_file_handler is not None:
+        flush = getattr(_dn_sync_file_handler, "flush", None)
         if callable(flush):
             flush()
 


### PR DESCRIPTION
## Summary
- reintroduce the DN sync child logger while keeping propagation to the shared logger so console output remains intact
- refresh the DN sync file handler when the log path changes and ensure it only records DN sync messages

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d65139d7d08320837371530832772d