### PR TITLE
Handle status_delivery alias in DN update

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -728,6 +728,10 @@ def update_dn(
     dnNumber: str = Form(...),
     status: str = Form(...),
     delivery_status: str | None = Form(None),
+    status_delivery: str | None = Form(
+        None,
+        description="Backward compatibility alias for delivery_status form field",
+    ),
     remark: str | None = Form(None),
     duId: str | None = Form(None),
     photo: UploadFile | None = File(None),
@@ -762,9 +766,13 @@ def update_dn(
         if updated_by_value == "":
             updated_by_value = None
 
+    delivery_status_raw = delivery_status
+    if delivery_status_raw is None and status_delivery is not None:
+        delivery_status_raw = status_delivery
+
     delivery_status_value = None
-    if delivery_status is not None:
-        delivery_status_value = delivery_status.strip()
+    if delivery_status_raw is not None:
+        delivery_status_value = delivery_status_raw.strip()
         if delivery_status_value == "":
             delivery_status_value = None
 


### PR DESCRIPTION
## Summary
- allow the `/api/dn/update` endpoint to accept both `delivery_status` and `status_delivery` form fields
- ensure whitespace trimming and dry-run logic work with the backward-compatible alias

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d68a0844988320a80a5023389333f7