### PR TITLE
Allow unlimited DN search when page size omitted

### DIFF
--- a/app/crud.py
+++ b/app/crud.py
@@ -428,7 +428,7 @@ def search_dn_records(
     date_from=None,
     date_to=None,
     page: int = 1,
-    page_size: int = 20,
+    page_size: Optional[int] = None,
 ) -> Tuple[int, List[DNRecord]]:
     base_q = db.query(DNRecord)
     conds = []
@@ -452,12 +452,11 @@ def search_dn_records(
         base_q = base_q.filter(and_(*conds))
 
     total = base_q.count()
-    items = (
-        base_q.order_by(DNRecord.created_at.desc(), DNRecord.id.desc())
-        .offset((page - 1) * page_size)
-        .limit(page_size)
-        .all()
-    )
+    ordered_q = base_q.order_by(DNRecord.created_at.desc(), DNRecord.id.desc())
+    if page_size is None:
+        items = ordered_q.all()
+    else:
+        items = ordered_q.offset((page - 1) * page_size).limit(page_size).all()
     return total, items
 
 

--- a/app/main.py
+++ b/app/main.py
@@ -1072,7 +1072,9 @@ def search_dn_records_api(
     date_from: Optional[datetime] = Query(None, description="起始时间(ISO 8601)"),
     date_to: Optional[datetime] = Query(None, description="结束时间(ISO 8601)"),
     page: int = Query(1, ge=1),
-    page_size: int = Query(20, ge=1, le=100),
+    page_size: Optional[int] = Query(
+        None, ge=1, description="每页数量，缺省时返回全部符合条件的数据"
+    ),
     db: Session = Depends(get_db),
 ):
     if dn_number:
@@ -1101,7 +1103,7 @@ def search_dn_records_api(
         "ok": True,
         "total": total,
         "page": page,
-        "page_size": page_size,
+        "page_size": page_size if page_size is not None else len(items),
         "items": [
             {
                 "id": it.id,


### PR DESCRIPTION
## Summary
- allow the DN search endpoint to omit `page_size` and return all matching rows without an enforced maximum
- update the search query to skip pagination when no page size is provided and report the actual returned size

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d766f954048320ba2155928946e8de