### PR TITLE
Add regression test ensuring archive note helper remains removed

### DIFF
--- a/tests/test_plan_mos_archiving_regression.py
+++ b/tests/test_plan_mos_archiving_regression.py
@@ -1,0 +1,10 @@
+from pathlib import Path
+
+
+def test_archive_note_column_helper_is_not_present():
+    main_path = Path(__file__).resolve().parents[1] / "app" / "main.py"
+    source = main_path.read_text(encoding="utf-8")
+
+    assert "ensure_archive_note_column" not in source
+    assert "Archive Note" not in source
+    assert "To Archive" not in source


### PR DESCRIPTION
## Summary
- add a regression test that scans `app/main.py` to verify the old `ensure_archive_note_column` helper and archive markers stay removed

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d887459330832080616e6371ac02c3