### PR TITLE
Load Google settings from environment

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,15 @@
+# Example environment configuration
+# Copy to .env and adjust the values for your deployment.
+APP_ENV=development
+DATABASE_URL=postgresql://username:password@localhost:5432/jakarta
+ALLOWED_ORIGINS=http://localhost:3000
+STORAGE_DRIVER=disk
+STORAGE_DISK_PATH=/data/uploads
+S3_ENDPOINT=
+S3_REGION=
+S3_BUCKET=
+S3_ACCESS_KEY=
+S3_SECRET_KEY=
+STORAGE_BASE_URL=
+GOOGLE_API_KEY=
+GOOGLE_SPREADSHEET_URL=

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.env
+__pycache__/

--- a/app/main.py
+++ b/app/main.py
@@ -71,6 +71,9 @@ from .logging_utils import logger
 os.makedirs(settings.storage_disk_path, exist_ok=True)
 app = FastAPI(title="DU Backend API", version="1.1.0")
 
+API_KEY = settings.google_api_key
+SPREADSHEET_URL = settings.google_spreadsheet_url
+
 GS_KEY_PATH = Path("/etc/secrets/gskey.json")
 try:
     gs_key_content = GS_KEY_PATH.read_text(encoding="utf-8")
@@ -1457,11 +1460,6 @@ def remove_dn_record(id: int, db: Session = Depends(get_db)):
     if not ok:
         raise HTTPException(status_code=404, detail="Record not found")
     return {"ok": True}
-
-
-# 设置全局变量
-API_KEY = "AIzaSyCxIBYFpNlPvQUXY83S559PEVXoagh8f88"
-SPREADSHEET_URL = "https://docs.google.com/spreadsheets/d/13-D-KkkbilYmlcHHa__CZkE2xtynL--ZxekZG4lWRic/edit?gid=1258103322#gid=1258103322"
 
 
 ARCHIVE_TEXT_COLOR = {"red": 0.6, "green": 0.6, "blue": 0.6}

--- a/app/settings.py
+++ b/app/settings.py
@@ -1,28 +1,60 @@
-# app/settings.py
-from pydantic_settings import BaseSettings
-import os
+"""Application settings management."""
+
+from __future__ import annotations
+
+from pydantic import AliasChoices, Field, ValidationError
+from pydantic_settings import BaseSettings, SettingsConfigDict
+
 
 class Settings(BaseSettings):
-    app_env: str = os.getenv("APP_ENV", "development")
-    database_url: str | None = os.getenv("DATABASE_URL")  # 不给默认，缺失就暴露问题
-    allowed_origins: list[str] = []
-    storage_driver: str = os.getenv("STORAGE_DRIVER", "disk")
-    storage_disk_path: str = os.getenv("storage_DISK_PATH", "/data/uploads")
-    s3_endpoint: str = os.getenv("S3_ENDPOINT", "")
-    s3_region: str = os.getenv("S3_REGION", "")
-    s3_bucket: str = os.getenv("S3_BUCKET", "")
-    s3_access_key: str = os.getenv("S3_ACCESS_KEY", "")
-    s3_secret_key: str = os.getenv("S3_SECRET_KEY", "")
-    storage_base_url: str = os.getenv("STORAGE_BASE_URL", "")
+    """Load settings from environment variables and a ``.env`` file."""
 
-settings = Settings()
+    model_config = SettingsConfigDict(env_file=".env", env_file_encoding="utf-8")
 
-raw = os.getenv("ALLOWED_ORIGINS", "")
-settings.allowed_origins = [x.strip() for x in raw.split(",") if x.strip()] or ["*"]
+    app_env: str = Field(default="development")
+    database_url: str = Field(alias="DATABASE_URL")
+    allowed_origins: str = Field(default="", alias="ALLOWED_ORIGINS")
+    storage_driver: str = Field(default="disk", alias="STORAGE_DRIVER")
+    storage_disk_path: str = Field(
+        default="/data/uploads",
+        validation_alias=AliasChoices("STORAGE_DISK_PATH", "storage_DISK_PATH"),
+    )
+    s3_endpoint: str = Field(default="", alias="S3_ENDPOINT")
+    s3_region: str = Field(default="", alias="S3_REGION")
+    s3_bucket: str = Field(default="", alias="S3_BUCKET")
+    s3_access_key: str = Field(default="", alias="S3_ACCESS_KEY")
+    s3_secret_key: str = Field(default="", alias="S3_SECRET_KEY")
+    storage_base_url: str = Field(default="", alias="STORAGE_BASE_URL")
+    google_api_key: str = Field(alias="GOOGLE_API_KEY")
+    google_spreadsheet_url: str = Field(alias="GOOGLE_SPREADSHEET_URL")
 
-# 校正 DATABASE_URL（必须存在）
-if not settings.database_url:
-    raise RuntimeError("Missing env DATABASE_URL")
+
+try:
+    settings = Settings()
+except ValidationError as exc:
+    missing_envs = set()
+    env_field_aliases = {
+        "database_url": "DATABASE_URL",
+        "google_api_key": "GOOGLE_API_KEY",
+        "google_spreadsheet_url": "GOOGLE_SPREADSHEET_URL",
+    }
+    for error in exc.errors():
+        if error.get("type") not in {"missing", "field_required"}:
+            continue
+        loc = error.get("loc") or ()
+        if not loc:
+            continue
+        field_name = loc[-1]
+        env_name = env_field_aliases.get(field_name, str(field_name))
+        missing_envs.add(env_name)
+
+    if missing_envs:
+        missing_list = ", ".join(sorted(missing_envs))
+        raise RuntimeError(f"Missing env variables: {missing_list}") from exc
+    raise
+
+raw_allowed = settings.allowed_origins
+settings.allowed_origins = [x.strip() for x in raw_allowed.split(",") if x.strip()] or ["*"]
 
 url = settings.database_url
 if url.startswith("postgres://"):


### PR DESCRIPTION
## Summary
- remove the config.ini loader and read Google API credentials from the existing Settings class
- require GOOGLE_API_KEY and GOOGLE_SPREADSHEET_URL to be supplied via the .env file
- document the new environment variables and drop the committed config.ini secret

## Testing
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68d8a719a75c8320851bc4dc7ff7f610