### PR TITLE
Fix DN list endpoint to return entries

### DIFF
--- a/app/api/dn/queries.py
+++ b/app/api/dn/queries.py
@@ -177,7 +177,7 @@ def list_dn_entries(
         if not DU_RE.fullmatch(du_id):
             raise HTTPException(status_code=400, detail=f"Invalid DU ID: {du_id}")
 
-    total, items = list_all_dn_records(
+    total, items = search_dn_list(
         db,
         dn_number=dn_number,
         du_id=du_id,


### PR DESCRIPTION
## Summary
- ensure the `/dn/list` endpoint fetches DN entries instead of DN records by reusing the entry search query

## Testing
- not run (environment not configured)


------
https://chatgpt.com/codex/tasks/task_e_68d8ef83e4fc832089af7e8eccdcfb99