### PR TITLE
Add LSP-based summary to status delivery stats endpoint

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -49,6 +49,7 @@ from .crud import (
     ensure_dn,
     get_dn_map_by_numbers,
     get_dn_status_delivery_counts,
+    get_dn_status_delivery_lsp_counts,
     get_dn_unique_field_values,
     get_existing_dn_numbers,
     get_latest_dn_records_map,
@@ -1612,11 +1613,26 @@ def get_dn_status_delivery_stats(
     normalized_lsp = lsp.strip() if lsp else None
     normalized_plan_mos_date = (plan_mos_date.strip() if plan_mos_date else None) or datetime.now().strftime("%d %b %y")
 
-    stats = get_dn_status_delivery_counts(db, lsp=normalized_lsp, plan_mos_date=normalized_plan_mos_date)
+    stats = get_dn_status_delivery_counts(
+        db, lsp=normalized_lsp, plan_mos_date=normalized_plan_mos_date
+    )
     total = sum(count for _, count in stats)
 
     data = [{"status_delivery": status, "count": count} for status, count in stats]
-    return {"ok": True, "data": data, "total": total}
+
+    lsp_stats = get_dn_status_delivery_lsp_counts(
+        db, lsp=normalized_lsp, plan_mos_date=normalized_plan_mos_date
+    )
+    lsp_summary = [
+        {
+            "lsp": lsp_value,
+            "total_dn": total_count,
+            "status_not_empty": status_count,
+        }
+        for lsp_value, total_count, status_count in lsp_stats
+    ]
+
+    return {"ok": True, "data": data, "total": total, "lsp_summary": lsp_summary}
 
 
 

--- a/tests/test_status_delivery_stats.py
+++ b/tests/test_status_delivery_stats.py
@@ -1,0 +1,101 @@
+import os
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+
+os.environ.setdefault("DATABASE_URL", "sqlite:///:memory:")
+
+
+from app.crud import (  # noqa: E402
+    get_dn_status_delivery_counts,
+    get_dn_status_delivery_lsp_counts,
+)
+from app.db import Base  # noqa: E402
+from app.models import DN  # noqa: E402
+
+
+@pytest.fixture
+def db_session():
+    engine = create_engine("sqlite:///:memory:", future=True)
+    Base.metadata.create_all(engine)
+    TestingSessionLocal = sessionmaker(
+        bind=engine, autoflush=False, autocommit=False, future=True
+    )
+    session = TestingSessionLocal()
+    try:
+        yield session
+    finally:
+        session.close()
+
+
+def _create_dn(
+    db_session,
+    *,
+    dn_number: str,
+    lsp: str | None,
+    plan_mos_date: str | None,
+    status: str | None,
+    status_delivery: str | None,
+):
+    db_session.add(
+        DN(
+            dn_number=dn_number,
+            lsp=lsp,
+            plan_mos_date=plan_mos_date,
+            status=status,
+            status_delivery=status_delivery,
+        )
+    )
+
+
+def test_status_delivery_and_lsp_counts(db_session):
+    _create_dn(
+        db_session,
+        dn_number="DN-1",
+        lsp="Alpha",
+        plan_mos_date="01 Jan 25",
+        status="Delivered",
+        status_delivery="POD",
+    )
+    _create_dn(
+        db_session,
+        dn_number="DN-2",
+        lsp="Alpha ",
+        plan_mos_date="01 Jan 25",
+        status="  ",
+        status_delivery="On Site",
+    )
+    _create_dn(
+        db_session,
+        dn_number="DN-3",
+        lsp="",
+        plan_mos_date="01 Jan 25",
+        status=None,
+        status_delivery=None,
+    )
+    _create_dn(
+        db_session,
+        dn_number="DN-4",
+        lsp="Beta",
+        plan_mos_date="02 Jan 25",
+        status="Delivered",
+        status_delivery="POD",
+    )
+    db_session.commit()
+
+    status_counts = get_dn_status_delivery_counts(
+        db_session, plan_mos_date="01 Jan 25"
+    )
+    assert dict(status_counts) == {"NO STATUS": 1, "On Site": 1, "POD": 1}
+
+    lsp_counts = get_dn_status_delivery_lsp_counts(
+        db_session, plan_mos_date="01 Jan 25"
+    )
+    assert lsp_counts == [("Alpha", 2, 1), ("NO LSP", 1, 0)]
+
+    alpha_only = get_dn_status_delivery_lsp_counts(
+        db_session, lsp=" Alpha", plan_mos_date="01 Jan 25"
+    )
+    assert alpha_only == [("Alpha", 2, 1)]


### PR DESCRIPTION
## Summary
- add a CRUD helper to compute plan_mos_date delivery counts grouped by LSP, including filled-status totals
- extend the `/api/dn/status-delivery/stats` response with the new `lsp_summary` metrics
- cover the aggregation logic with unit tests for mixed LSP/status scenarios

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68da035f83c08320bdf6e21cc2e61f8b