### PR TITLE
Add hourly LSP summary capture and history endpoint

### DIFF
--- a/app/core/status_delivery_summary.py
+++ b/app/core/status_delivery_summary.py
@@ -1,0 +1,76 @@
+"""Utilities for recording hourly status-delivery LSP summaries."""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import datetime, timezone
+from typing import Sequence
+
+from app.crud import (
+    get_dn_status_delivery_lsp_counts,
+    upsert_status_delivery_lsp_stats,
+)
+from app.db import SessionLocal
+from app.models import StatusDeliveryLspStat
+from app.utils.logging import logger
+
+PLAN_MOS_DATE_FORMAT = "%d %b %y"
+
+__all__ = [
+    "PLAN_MOS_DATE_FORMAT",
+    "capture_status_delivery_lsp_summary",
+    "scheduled_status_delivery_lsp_summary_capture",
+]
+
+
+def capture_status_delivery_lsp_summary(
+    plan_mos_date: str | None = None,
+) -> Sequence[StatusDeliveryLspStat]:
+    """Collect and persist the latest LSP summary statistics."""
+
+    normalized_plan_mos_date = (plan_mos_date.strip() if plan_mos_date else None) or datetime.now().strftime(PLAN_MOS_DATE_FORMAT)
+
+    recorded_at = datetime.now(timezone.utc).replace(minute=0, second=0, microsecond=0)
+
+    db = SessionLocal()
+    try:
+        lsp_stats = get_dn_status_delivery_lsp_counts(
+            db, plan_mos_date=normalized_plan_mos_date
+        )
+
+        if not lsp_stats:
+            logger.info(
+                "No LSP summary data available for plan MOS date %s", normalized_plan_mos_date
+            )
+            return []
+
+        records = [
+            {
+                "lsp": lsp_value,
+                "total_dn": total_count,
+                "status_not_empty": status_count,
+                "plan_mos_date": normalized_plan_mos_date,
+                "recorded_at": recorded_at,
+            }
+            for lsp_value, total_count, status_count in lsp_stats
+        ]
+
+        persisted = upsert_status_delivery_lsp_stats(db, records)
+        logger.info(
+            "Stored %d LSP summary rows for plan MOS date %s at %s",
+            len(persisted),
+            normalized_plan_mos_date,
+            recorded_at.isoformat(),
+        )
+        return persisted
+    finally:
+        db.close()
+
+
+async def scheduled_status_delivery_lsp_summary_capture() -> None:
+    """Background job entrypoint for hourly LSP summary snapshots."""
+
+    try:
+        await asyncio.to_thread(capture_status_delivery_lsp_summary)
+    except Exception:
+        logger.exception("Failed to record status-delivery LSP summary")

--- a/app/models.py
+++ b/app/models.py
@@ -1,5 +1,5 @@
 import json
-from sqlalchemy import Column, String, Integer, DateTime, Text
+from sqlalchemy import Column, String, Integer, DateTime, Text, UniqueConstraint
 from sqlalchemy.sql import func
 from .db import Base
 
@@ -107,3 +107,22 @@ class DNSyncLog(Base):
         if isinstance(data, list):
             return data
         return []
+
+
+class StatusDeliveryLspStat(Base):
+    __tablename__ = "status_delivery_lsp_stat"
+    __table_args__ = (
+        UniqueConstraint(
+            "lsp",
+            "recorded_at",
+            name="uq_status_delivery_lsp_stat_lsp_recorded_at",
+        ),
+    )
+
+    id = Column(Integer, primary_key=True, index=True)
+    lsp = Column(String(128), nullable=False, index=True)
+    total_dn = Column(Integer, nullable=False)
+    status_not_empty = Column(Integer, nullable=False)
+    plan_mos_date = Column(String(32), nullable=False)
+    recorded_at = Column(DateTime(timezone=True), nullable=False, index=True)
+    created_at = Column(DateTime(timezone=True), server_default=func.now(), nullable=False)

--- a/app/schemas/dn.py
+++ b/app/schemas/dn.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from datetime import datetime
 from typing import List
 
 from pydantic import BaseModel, Field
@@ -12,6 +13,8 @@ __all__ = [
     "StatusDeliveryCount",
     "StatusDeliveryLspSummary",
     "StatusDeliveryStatsResponse",
+    "StatusDeliveryLspSummaryRecord",
+    "StatusDeliveryLspSummaryHistoryResponse",
 ]
 
 
@@ -52,4 +55,24 @@ class StatusDeliveryStatsResponse(BaseModel):
     total: int = Field(..., ge=0, description="Total DN rows matching the filters")
     lsp_summary: List[StatusDeliveryLspSummary] = Field(
         ..., description="Aggregated LSP summary metrics"
+    )
+
+
+class StatusDeliveryLspSummaryRecord(BaseModel):
+    id: int = Field(..., description="Identifier of the recorded summary row")
+    lsp: str = Field(..., description="Logistics service provider name")
+    total_dn: int = Field(..., ge=0, description="Total DN rows counted in the snapshot")
+    status_not_empty: int = Field(
+        ..., ge=0, description="Rows within the snapshot whose status column is not empty"
+    )
+    plan_mos_date: str = Field(..., description="Plan MOS date used when generating the snapshot")
+    recorded_at: datetime = Field(
+        ..., description="Timestamp when the snapshot was captured"
+    )
+
+
+class StatusDeliveryLspSummaryHistoryResponse(BaseModel):
+    ok: bool = Field(True, description="Whether the request succeeded")
+    data: List[StatusDeliveryLspSummaryRecord] = Field(
+        ..., description="Historical status-delivery LSP summary snapshots"
     )


### PR DESCRIPTION
## Summary
- add a database model and background job to persist hourly LSP snapshots from the status-delivery stats
- expose an API endpoint and schemas to query stored LSP summary history with optional filtering
- cover the new persistence and API logic with unit tests

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68da602e26b88320ab7469e14d3cc86d