### PR TITLE
Fix DN_RE digit range to allow 10–15 digits

### DIFF
--- a/app/constants.py
+++ b/app/constants.py
@@ -18,7 +18,7 @@ __all__ = [
 ]
 
 # Regular expression for DN number validation
-DN_RE = re.compile(r"^[A-Za-z]{2,5}\d{11,16}$")
+DN_RE = re.compile(r"^[A-Za-z]{2,5}\d{10,15}$")
 
 # Valid DN statuses
 VALID_STATUSES: tuple[str, ...] = (


### PR DESCRIPTION
### Motivation
- Correct DN number validation to accept DN numbers with 10–15 numeric digits instead of 11–16, addressing an off-by-one range error in the regex.

### Description
- Update `DN_RE` in `app/constants.py` from `r'^[A-Za-z]{2,5}\d{11,16}$'` to `r'^[A-Za-z]{2,5}\d{10,15}$'` to change the allowed digit count.

### Testing
- No automated tests were run or modified for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dcddd6cf088324bbf0e57c573e0901)