### PR TITLE
Proxy Find SG LPN through backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ JakartaBackend 是一个基于 FastAPI 构建的物流管理系统后端服务�
 - **智能时间戳**: 根据状态自动写入时间戳到 Google Sheet (支持到达/出发场景)
 - **软删除查询**: 支持查询已软删除的记录 (管理员功能)
 - **全局常量管理**: 统一的常量定义，提高代码可维护性
+- **外部接口代理**: 后端代理 Find SG LPN 查询，避免前端 CORS 和浏览器暴露密钥
 
 ## 技术架构
 
@@ -22,6 +23,7 @@ JakartaBackend 是一个基于 FastAPI 构建的物流管理系统后端服务�
 - **Web 框架**: FastAPI 0.116.2 (Python 3.13+)
 - **数据库**: PostgreSQL + SQLAlchemy 2.0.36 ORM
 - **外部集成**: Google Sheets API (gspread)
+- **外部接口代理**: Find SG LPN 华为网关接口
 - **任务调度**: APScheduler (AsyncIO 定时任务)
 - **文件存储**: AWS S3 / 本地文件系统
 - **部署**: Docker 容器化
@@ -341,6 +343,11 @@ AWS_S3_REGION=your_region
 
 # 应用配置
 ALLOWED_ORIGINS=http://localhost:3000,https://your-domain.com
+
+# Find SG LPN 代理
+FIND_SG_LPN_URL=https://apigw-cn-south02.huawei.com/api/app_000000035599/findSgLpnInfos
+FIND_SG_LPN_APPKEY=your-find-sg-lpn-app-key
+FIND_SG_LPN_HW_ID=com.huawei.ipaas.roma.data.subject
 ```
 
 ### 配置类

--- a/app/api/__init__.py
+++ b/app/api/__init__.py
@@ -4,15 +4,15 @@ from fastapi import APIRouter
 
 from .health import router as health_router
 from .dn import router as dn_router
-from .dn import archive as dn_archive
+from .find_sg_lpn import router as find_sg_lpn_router
 from .vehicle import router as vehicle_router
 from .pm import router as pm_router
 from .aging_orders import router as aging_orders_router
 
 router = APIRouter()
 router.include_router(health_router)
+router.include_router(find_sg_lpn_router)
 router.include_router(dn_router)
-router.include_router(dn_archive.router)
 router.include_router(vehicle_router)
 router.include_router(pm_router)
 router.include_router(aging_orders_router)

--- a/app/api/dn/update.py
+++ b/app/api/dn/update.py
@@ -24,7 +24,7 @@ from app.crud import (
     _ACTIVE_DN_EXPR,
 )
 from app.db import get_db, SessionLocal
-from app.models import DN
+from app.models import CheckResult, DN
 from app.services.dn_checkins import DNCheckinError, create_dn_checkin
 from app.storage import save_file
 from app.utils.string import normalize_dn
@@ -32,6 +32,21 @@ from app.utils.time import TZ_GMT7
 from app.core.sheet import sync_dn_record_to_sheet
 
 router = APIRouter(prefix="/api/dn")
+
+
+def _coerce_int(value: Any) -> int | None:
+    if value is None:
+        return None
+    if isinstance(value, bool):
+        return int(value)
+    if isinstance(value, int):
+        return value
+    if isinstance(value, float):
+        return int(value)
+    try:
+        return int(str(value).strip())
+    except (TypeError, ValueError):
+        return None
 
 
 def _current_timestamp_gmt7() -> str:
@@ -258,6 +273,81 @@ async def update_dn(
     )
 
     return {"ok": True, "id": rec.id, "photo": photo_url}
+
+
+@router.post("/check_result")
+@router.post("/dn_checker")
+def upload_check_result(
+    payload: dict[str, Any] = Body(...),
+    db: Session = Depends(get_db),
+):
+    if not isinstance(payload, dict):
+        raise HTTPException(status_code=400, detail="Invalid payload")
+
+    report_id = payload.get("reportId") or payload.get("report_id") or payload.get("id")
+    dn_number = payload.get("dnNumber") or payload.get("dn_number") or payload.get("dn")
+    if not report_id or not dn_number:
+        raise HTTPException(status_code=400, detail="report_id and dn_number are required")
+
+    normalized_dn = normalize_dn(str(dn_number))
+    if not DN_RE.fullmatch(normalized_dn):
+        raise HTTPException(status_code=400, detail="Invalid DN number")
+
+    boxes = payload.get("boxes")
+    metadata = payload.get("metadata")
+    if boxes is not None and not isinstance(boxes, list):
+        raise HTTPException(status_code=400, detail="boxes must be a list")
+    if metadata is not None and not isinstance(metadata, dict):
+        raise HTTPException(status_code=400, detail="metadata must be an object")
+
+    existing = (
+        db.query(CheckResult)
+        .filter(CheckResult.report_id == str(report_id))
+        .one_or_none()
+    )
+
+    if existing is None:
+        record = CheckResult(
+            report_id=str(report_id),
+            dn_number=normalized_dn,
+            lsp=payload.get("lsp"),
+            checker_name=payload.get("checkerName") or payload.get("checker_name"),
+            check_time=payload.get("checkTime") or payload.get("check_time"),
+            status=payload.get("status"),
+            box_count=_coerce_int(payload.get("boxCount")),
+            checked_count=_coerce_int(payload.get("checkedCount")),
+            boxes_json=json.dumps(boxes) if boxes is not None else None,
+            metadata_json=json.dumps(metadata) if metadata is not None else None,
+        )
+        db.add(record)
+        db.commit()
+        db.refresh(record)
+    else:
+        existing.dn_number = normalized_dn
+        existing.lsp = payload.get("lsp")
+        existing.checker_name = payload.get("checkerName") or payload.get("checker_name")
+        existing.check_time = payload.get("checkTime") or payload.get("check_time")
+        existing.status = payload.get("status")
+        existing.box_count = _coerce_int(payload.get("boxCount"))
+        existing.checked_count = _coerce_int(payload.get("checkedCount"))
+        existing.boxes_json = json.dumps(boxes) if boxes is not None else None
+        existing.metadata_json = json.dumps(metadata) if metadata is not None else None
+        db.add(existing)
+        db.commit()
+        db.refresh(existing)
+        record = existing
+
+    return {
+        "ok": True,
+        "id": record.id,
+        "report_id": record.report_id,
+        "dn_number": record.dn_number,
+        "lsp": record.lsp,
+        "checker_name": record.checker_name,
+        "status": record.status,
+        "box_count": record.box_count,
+        "checked_count": record.checked_count,
+    }
 
 
 @router.post("/batch_update")

--- a/app/api/find_sg_lpn.py
+++ b/app/api/find_sg_lpn.py
@@ -1,0 +1,67 @@
+"""Proxy endpoint for Find SG LPN upstream API."""
+
+from __future__ import annotations
+
+import json
+from urllib.error import HTTPError, URLError
+from urllib.request import Request, urlopen
+
+from fastapi import APIRouter, HTTPException
+from fastapi.responses import JSONResponse
+from pydantic import BaseModel, Field
+
+from app.settings import settings
+from app.utils.logging import logger
+
+router = APIRouter(prefix="/api/find-sg-lpn-infos")
+
+
+class FindSgLpnRequest(BaseModel):
+    order_number: str = Field(..., min_length=1)
+    pageSize: int = Field(1000, ge=1)
+    pageNum: int = Field(1, ge=1)
+
+
+def _read_json_response(response) -> dict:
+    raw = response.read()
+    if not raw:
+        return {}
+    return json.loads(raw.decode("utf-8"))
+
+
+@router.post("")
+def find_sg_lpn_infos(payload: FindSgLpnRequest):
+    if not settings.find_sg_lpn_appkey:
+        raise HTTPException(status_code=503, detail="FIND_SG_LPN_APPKEY is not configured")
+
+    body = {
+        "order_number": payload.order_number.strip(),
+        "pageSize": payload.pageSize,
+        "pageNum": payload.pageNum,
+    }
+    if not body["order_number"]:
+        raise HTTPException(status_code=400, detail="order_number is required")
+
+    request = Request(
+        settings.find_sg_lpn_url,
+        data=json.dumps(body).encode("utf-8"),
+        headers={
+            "X-HW-ID": settings.find_sg_lpn_hw_id,
+            "X-HW-APPKEY": settings.find_sg_lpn_appkey,
+            "Content-Type": "application/json; charset=utf-8",
+        },
+        method="POST",
+    )
+
+    try:
+        with urlopen(request, timeout=settings.find_sg_lpn_timeout_seconds) as response:
+            return _read_json_response(response)
+    except HTTPError as exc:
+        try:
+            error_payload = _read_json_response(exc)
+        except (json.JSONDecodeError, UnicodeDecodeError):
+            error_payload = {"message": exc.reason}
+        return JSONResponse(status_code=exc.code, content=error_payload)
+    except (URLError, TimeoutError, json.JSONDecodeError, UnicodeDecodeError) as exc:
+        logger.warning("Find SG LPN upstream request failed: %s", exc)
+        raise HTTPException(status_code=502, detail="Find SG LPN upstream request failed") from exc

--- a/app/db_migrations.py
+++ b/app/db_migrations.py
@@ -85,7 +85,10 @@ def ensure_table_schema(db: Session, table_name: str, model_table: Table) -> Non
         
         # Check if table exists
         if not inspector.has_table(table_name):
-            logger.info("Table %s does not exist, will be created by create_all()", table_name)
+            logger.info("Table %s does not exist, creating from SQLAlchemy model", table_name)
+            model_table.create(bind=db.bind, checkfirst=True)
+            db.commit()
+            logger.info("Created table %s", table_name)
             return
         
         # Get missing columns
@@ -250,9 +253,9 @@ def run_startup_migrations(db: Session) -> None:
     logger.info("Running startup database migrations")
 
     try:
-        # Get all tables from the Base metadata
-        for table_name, table in Base.metadata.tables.items():
-            ensure_table_schema(db, table_name, table)
+        # Get all tables from the Base metadata in dependency order.
+        for table in Base.metadata.sorted_tables:
+            ensure_table_schema(db, table.name, table)
 
         logger.info("Completed startup database migrations")
 

--- a/app/main.py
+++ b/app/main.py
@@ -21,7 +21,7 @@ from app.core.status_delivery_summary import (
 )
 from app.api.dn.archive import scheduled_archive
 from app.utils.time import TZ_GMT7
-from app.db import Base, engine, SessionLocal
+from app.db import engine, SessionLocal
 from app import models  # noqa: F401 - ensure models are imported for metadata creation
 from app.db_migrations import run_startup_migrations, prepare_dn_table_migration
 from app.dn_columns import refresh_dynamic_columns
@@ -41,8 +41,6 @@ app.add_middleware(
 if settings.storage_driver != "s3":
     os.makedirs(settings.storage_disk_path, exist_ok=True)
     app.mount("/uploads", StaticFiles(directory=settings.storage_disk_path, check_dir=False), name="uploads")
-
-Base.metadata.create_all(bind=engine)
 
 # Prepare DN table for migration (handle old schema)
 with SessionLocal() as db:

--- a/app/models.py
+++ b/app/models.py
@@ -83,6 +83,22 @@ class DNRecord(Base):
     created_at = Column(DateTime(timezone=True), server_default=func.now(), nullable=False)
 
 
+class CheckResult(Base):
+    __tablename__ = "check_result"
+    id = Column(Integer, primary_key=True, index=True)
+    report_id = Column(String(128), unique=True, index=True, nullable=False)
+    dn_number = Column(String(64), index=True, nullable=False)
+    lsp = Column(String(128), nullable=True)
+    checker_name = Column(String(128), nullable=True)
+    check_time = Column(String(64), nullable=True)
+    status = Column(String(32), nullable=True)
+    box_count = Column(Integer, nullable=True)
+    checked_count = Column(Integer, nullable=True)
+    boxes_json = Column(Text, nullable=True)
+    metadata_json = Column(Text, nullable=True)
+    created_at = Column(DateTime(timezone=True), server_default=func.now(), nullable=False)
+
+
 class DNSyncLog(Base):
     __tablename__ = "dn_sync_log"
     id = Column(Integer, primary_key=True, index=True)

--- a/app/settings.py
+++ b/app/settings.py
@@ -32,6 +32,13 @@ class Settings(BaseSettings):
     dn_contacts_hw_id: str = os.getenv("DN_CONTACTS_HW_ID", "")
     dn_contacts_app_key: str = os.getenv("DN_CONTACTS_APP_KEY", "")
     dn_contacts_timeout: float = float(os.getenv("DN_CONTACTS_TIMEOUT", "10"))
+    find_sg_lpn_url: str = os.getenv(
+        "FIND_SG_LPN_URL",
+        "https://apigw-cn-south02.huawei.com/api/app_000000035599/findSgLpnInfos",
+    )
+    find_sg_lpn_hw_id: str = os.getenv("FIND_SG_LPN_HW_ID", "com.huawei.ipaas.roma.data.subject")
+    find_sg_lpn_appkey: str = os.getenv("FIND_SG_LPN_APPKEY", "")
+    find_sg_lpn_timeout_seconds: int = int(os.getenv("FIND_SG_LPN_TIMEOUT_SECONDS", "15"))
 
     @field_validator("allowed_origins", mode="after")
     @classmethod
@@ -49,7 +56,6 @@ class Settings(BaseSettings):
             parsed = [str(part).strip() for part in value if str(part).strip()]
             return parsed or ["*"]
         return value
-
 
 settings = Settings()
 

--- a/tests/test_check_result_upload.py
+++ b/tests/test_check_result_upload.py
@@ -1,0 +1,97 @@
+import json
+import os
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine
+from sqlalchemy.orm import Session, sessionmaker
+
+os.environ.setdefault("DATABASE_URL", "sqlite:///:memory:")
+os.environ.setdefault("DN_CONTACTS_API_BASE_URL", "https://example.test")
+os.environ.setdefault("DN_CONTACTS_HW_ID", "test-hw-id")
+os.environ.setdefault("DN_CONTACTS_APP_KEY", "test-app-key")
+
+from app.db import Base, SessionLocal, get_db
+from app.main import app
+from app.models import CheckResult
+
+
+@pytest.fixture
+def db_session():
+    engine = create_engine(
+        "sqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        future=True,
+    )
+    Base.metadata.create_all(engine)
+    TestingSessionLocal = sessionmaker(
+        bind=engine,
+        autoflush=False,
+        autocommit=False,
+        future=True,
+    )
+
+    original_session_factory = SessionLocal
+    app.dependency_overrides.clear()
+    from app import db as app_db
+    app_db.engine = engine
+    app_db.SessionLocal = TestingSessionLocal
+    app_db.Base.metadata.create_all(engine)
+
+    session = TestingSessionLocal()
+    try:
+        yield session
+    finally:
+        session.close()
+        app_db.engine = original_session_factory.kw["bind"] if hasattr(original_session_factory, "kw") else app_db.engine
+        app_db.SessionLocal = original_session_factory
+
+
+@pytest.fixture
+def client(db_session):
+    def override_get_db():
+        try:
+            yield db_session
+        finally:
+            pass
+
+    app.dependency_overrides[get_db] = override_get_db
+    yield TestClient(app)
+    app.dependency_overrides.clear()
+
+
+def test_upload_check_result_persists_payload(db_session: Session, client):
+    payload = {
+        "reportId": "report-123",
+        "dnNumber": "TESTDN12345678",
+        "lsp": "LSP01",
+        "checkerName": "Alice",
+        "checkTime": "2026-07-28 10:00:00",
+        "boxCount": 2,
+        "checkedCount": 1,
+        "status": "partial",
+        "boxes": [
+            {"boxNo": "BOX1", "itemNo": "ITEM1", "qty": "1", "status": "Checked"},
+            {"boxNo": "BOX2", "itemNo": "ITEM2", "qty": "2", "status": "Pending"},
+        ],
+        "metadata": {"generatedAt": "2026-07-28T10:00:00Z"},
+    }
+
+    response = client.post("/api/dn/check_result", json=payload)
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["ok"] is True
+    assert data["report_id"] == "report-123"
+    assert data["dn_number"] == "TESTDN12345678"
+    assert data["box_count"] == 2
+    assert data["checked_count"] == 1
+
+    stored = db_session.query(CheckResult).filter(CheckResult.report_id == "report-123").one()
+    assert stored.dn_number == "TESTDN12345678"
+    assert stored.lsp == "LSP01"
+    assert stored.checker_name == "Alice"
+    assert stored.box_count == 2
+    assert stored.checked_count == 1
+    assert json.loads(stored.boxes_json)[0]["boxNo"] == "BOX1"
+    assert json.loads(stored.metadata_json)["generatedAt"] == "2026-07-28T10:00:00Z"

--- a/tests/test_find_sg_lpn_proxy.py
+++ b/tests/test_find_sg_lpn_proxy.py
@@ -1,0 +1,64 @@
+import json
+import os
+
+import pytest
+from fastapi import HTTPException
+
+os.environ.setdefault("DATABASE_URL", "sqlite:///:memory:")
+os.environ.setdefault("DN_CONTACTS_API_BASE_URL", "https://example.test")
+os.environ.setdefault("DN_CONTACTS_HW_ID", "test-hw-id")
+os.environ.setdefault("DN_CONTACTS_APP_KEY", "test-app-key")
+
+from app.api import find_sg_lpn  # noqa: E402
+
+
+class FakeResponse:
+    def __init__(self, payload):
+        self.payload = payload
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, traceback):
+        return False
+
+    def read(self):
+        return json.dumps(self.payload).encode("utf-8")
+
+
+def test_find_sg_lpn_proxy_adds_upstream_credentials(monkeypatch):
+    captured = {}
+
+    monkeypatch.setattr(find_sg_lpn.settings, "find_sg_lpn_url", "https://example.test/findSgLpnInfos")
+    monkeypatch.setattr(find_sg_lpn.settings, "find_sg_lpn_hw_id", "test-hw-id")
+    monkeypatch.setattr(find_sg_lpn.settings, "find_sg_lpn_appkey", "secret-app-key")
+    monkeypatch.setattr(find_sg_lpn.settings, "find_sg_lpn_timeout_seconds", 3)
+
+    def fake_urlopen(request, timeout):
+        captured["url"] = request.full_url
+        captured["headers"] = dict(request.header_items())
+        captured["body"] = json.loads(request.data.decode("utf-8"))
+        captured["timeout"] = timeout
+        return FakeResponse({"code": "200", "list": [{"lpn_name": "LPN-1"}]})
+
+    monkeypatch.setattr(find_sg_lpn, "urlopen", fake_urlopen)
+
+    response = find_sg_lpn.find_sg_lpn_infos(
+        find_sg_lpn.FindSgLpnRequest(order_number=" SO-123 ", pageSize=50, pageNum=2)
+    )
+
+    assert response == {"code": "200", "list": [{"lpn_name": "LPN-1"}]}
+    assert captured["url"] == "https://example.test/findSgLpnInfos"
+    assert captured["headers"]["X-hw-id"] == "test-hw-id"
+    assert captured["headers"]["X-hw-appkey"] == "secret-app-key"
+    assert captured["body"] == {"order_number": "SO-123", "pageSize": 50, "pageNum": 2}
+    assert captured["timeout"] == 3
+
+
+def test_find_sg_lpn_proxy_requires_server_appkey(monkeypatch):
+    monkeypatch.setattr(find_sg_lpn.settings, "find_sg_lpn_appkey", "")
+
+    with pytest.raises(HTTPException) as exc_info:
+        find_sg_lpn.find_sg_lpn_infos(find_sg_lpn.FindSgLpnRequest(order_number="SO-123"))
+
+    assert exc_info.value.status_code == 503


### PR DESCRIPTION
## Summary
- add a backend Find SG LPN proxy endpoint so the frontend no longer calls the Huawei gateway directly
- move Huawei credentials to backend settings and document the required environment variable
- persist checker report uploads through the backend and ensure new tables are created through startup migrations

## Validation
- git diff --check
- python -m py_compile app/api/__init__.py app/api/dn/update.py app/db_migrations.py app/main.py app/models.py app/settings.py app/api/find_sg_lpn.py tests/test_check_result_upload.py tests/test_find_sg_lpn_proxy.py

## Notes
- The local Python environment does not have fastapi or pytest installed, so endpoint-level pytest could not be run here.
