### PR TITLE
Return Find SG LPN upstream error detail

### DIFF
--- a/app/api/dn/update.py
+++ b/app/api/dn/update.py
@@ -4,10 +4,10 @@ from __future__ import annotations
 
 from typing import Any, List, Optional
 import json
-from datetime import datetime
+from datetime import date, datetime, time, timezone
 from app.utils.logging import logger
 
-from fastapi import APIRouter, BackgroundTasks, Body, Depends, File, Form, HTTPException, UploadFile
+from fastapi import APIRouter, BackgroundTasks, Body, Depends, File, Form, HTTPException, Query, UploadFile
 from sqlalchemy.orm import Session
 
 from app.constants import (
@@ -47,6 +47,41 @@ def _coerce_int(value: Any) -> int | None:
         return int(str(value).strip())
     except (TypeError, ValueError):
         return None
+
+
+def _json_loads_or_default(value: str | None, default: Any) -> Any:
+    if not value:
+        return default
+    try:
+        return json.loads(value)
+    except Exception:
+        return default
+
+
+def _check_result_created_date_range(value: date | None) -> tuple[datetime, datetime]:
+    local_date = value or datetime.now(TZ_GMT7).date()
+    start = datetime.combine(local_date, time(0, 0, 0), tzinfo=TZ_GMT7)
+    end = datetime.combine(local_date, time(23, 59, 59, 999_999), tzinfo=TZ_GMT7)
+    return start.astimezone(timezone.utc), end.astimezone(timezone.utc)
+
+
+def _serialize_check_result(record: CheckResult, *, include_details: bool = False) -> dict[str, Any]:
+    data: dict[str, Any] = {
+        "id": record.id,
+        "report_id": record.report_id,
+        "dn_number": record.dn_number,
+        "lsp": record.lsp,
+        "checker_name": record.checker_name,
+        "check_time": record.check_time,
+        "status": record.status,
+        "box_count": record.box_count,
+        "checked_count": record.checked_count,
+        "created_at": record.created_at.isoformat() if record.created_at else None,
+    }
+    if include_details:
+        data["boxes"] = _json_loads_or_default(record.boxes_json, [])
+        data["metadata"] = _json_loads_or_default(record.metadata_json, {})
+    return data
 
 
 def _current_timestamp_gmt7() -> str:
@@ -348,6 +383,53 @@ def upload_check_result(
         "box_count": record.box_count,
         "checked_count": record.checked_count,
     }
+
+
+@router.get("/check_result")
+def list_check_results(
+    date_value: date | None = Query(None, alias="date", description="Record created date in YYYY-MM-DD; defaults to today in GMT+7"),
+    page: int = Query(1, ge=1),
+    page_size: int = Query(20, ge=1, le=200),
+    dn_number: str | None = Query(None, description="Optional DN number filter"),
+    db: Session = Depends(get_db),
+):
+    start, end = _check_result_created_date_range(date_value)
+    query = db.query(CheckResult).filter(
+        CheckResult.created_at >= start,
+        CheckResult.created_at <= end,
+    )
+
+    if dn_number and dn_number.strip():
+        normalized_dn = normalize_dn(dn_number)
+        query = query.filter(CheckResult.dn_number == normalized_dn)
+
+    total = query.count()
+    records = (
+        query.order_by(CheckResult.created_at.desc(), CheckResult.id.desc())
+        .offset((page - 1) * page_size)
+        .limit(page_size)
+        .all()
+    )
+
+    return {
+        "ok": True,
+        "date": (date_value or datetime.now(TZ_GMT7).date()).isoformat(),
+        "total": total,
+        "page": page,
+        "page_size": page_size,
+        "items": [_serialize_check_result(record) for record in records],
+    }
+
+
+@router.get("/check_result/{result_id}")
+def get_check_result(
+    result_id: int,
+    db: Session = Depends(get_db),
+):
+    record = db.query(CheckResult).filter(CheckResult.id == result_id).one_or_none()
+    if record is None:
+        raise HTTPException(status_code=404, detail="Check result not found")
+    return {"ok": True, "item": _serialize_check_result(record, include_details=True)}
 
 
 @router.post("/batch_update")

--- a/app/api/find_sg_lpn.py
+++ b/app/api/find_sg_lpn.py
@@ -29,6 +29,13 @@ def _read_json_response(response) -> dict:
     return json.loads(raw.decode("utf-8"))
 
 
+def _upstream_error_detail(exc: BaseException) -> str:
+    reason = getattr(exc, "reason", None)
+    if reason:
+        return f"Find SG LPN upstream request failed: {reason}"
+    return f"Find SG LPN upstream request failed: {exc}"
+
+
 @router.post("")
 def find_sg_lpn_infos(payload: FindSgLpnRequest):
     if not settings.find_sg_lpn_appkey:
@@ -61,7 +68,11 @@ def find_sg_lpn_infos(payload: FindSgLpnRequest):
             error_payload = _read_json_response(exc)
         except (json.JSONDecodeError, UnicodeDecodeError):
             error_payload = {"message": exc.reason}
+        if isinstance(error_payload, dict) and not any(
+            error_payload.get(key) for key in ("errorMsg", "message", "detail")
+        ):
+            error_payload["detail"] = f"Find SG LPN upstream returned HTTP {exc.code}: {exc.reason}"
         return JSONResponse(status_code=exc.code, content=error_payload)
     except (URLError, TimeoutError, json.JSONDecodeError, UnicodeDecodeError) as exc:
         logger.warning("Find SG LPN upstream request failed: %s", exc)
-        raise HTTPException(status_code=502, detail="Find SG LPN upstream request failed") from exc
+        raise HTTPException(status_code=502, detail=_upstream_error_detail(exc)) from exc

--- a/tests/test_check_result_upload.py
+++ b/tests/test_check_result_upload.py
@@ -1,5 +1,6 @@
 import json
 import os
+from datetime import datetime, timezone
 
 import pytest
 from fastapi.testclient import TestClient
@@ -95,3 +96,63 @@ def test_upload_check_result_persists_payload(db_session: Session, client):
     assert stored.checked_count == 1
     assert json.loads(stored.boxes_json)[0]["boxNo"] == "BOX1"
     assert json.loads(stored.metadata_json)["generatedAt"] == "2026-07-28T10:00:00Z"
+
+
+def test_list_check_results_filters_by_created_date(db_session: Session, client):
+    first = CheckResult(
+        report_id="report-list-1",
+        dn_number="TESTDN12345678",
+        lsp="LSP01",
+        checker_name="Alice",
+        check_time="2026-07-28 10:00:00",
+        status="completed",
+        box_count=2,
+        checked_count=2,
+        boxes_json=json.dumps([{"boxNo": "BOX1", "status": "Checked"}]),
+        created_at=datetime(2026, 7, 28, 4, 0, tzinfo=timezone.utc),
+    )
+    second = CheckResult(
+        report_id="report-list-2",
+        dn_number="TESTDN87654321",
+        checker_name="Bob",
+        status="completed",
+        box_count=1,
+        checked_count=1,
+        created_at=datetime(2026, 7, 29, 4, 0, tzinfo=timezone.utc),
+    )
+    db_session.add_all([first, second])
+    db_session.commit()
+
+    response = client.get("/api/dn/check_result", params={"date": "2026-07-28"})
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["ok"] is True
+    assert data["total"] == 1
+    assert data["items"][0]["report_id"] == "report-list-1"
+    assert data["items"][0]["dn_number"] == "TESTDN12345678"
+
+
+def test_get_check_result_returns_detail_payload(db_session: Session, client):
+    record = CheckResult(
+        report_id="report-detail-1",
+        dn_number="TESTDN12345678",
+        checker_name="Alice",
+        status="completed",
+        box_count=1,
+        checked_count=1,
+        boxes_json=json.dumps([{"boxNo": "BOX1", "itemNo": "ITEM1", "status": "Checked"}]),
+        metadata_json=json.dumps({"generatedAt": "2026-07-28T10:00:00Z"}),
+    )
+    db_session.add(record)
+    db_session.commit()
+    db_session.refresh(record)
+
+    response = client.get(f"/api/dn/check_result/{record.id}")
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["ok"] is True
+    assert data["item"]["report_id"] == "report-detail-1"
+    assert data["item"]["boxes"][0]["boxNo"] == "BOX1"
+    assert data["item"]["metadata"]["generatedAt"] == "2026-07-28T10:00:00Z"


### PR DESCRIPTION
## Summary
- return non-secret upstream failure detail from the Find SG LPN proxy
- preserve upstream HTTP error payloads while adding a fallback detail when the payload has no message

## Validation
- python -m py_compile app/api/find_sg_lpn.py
